### PR TITLE
Document our commitment to standards

### DIFF
--- a/.vitepress/config.mjs
+++ b/.vitepress/config.mjs
@@ -50,7 +50,8 @@ export default defineConfig({
         text: "Engineering",
         items: [
           {text: "Technologies", link: 'engineering/technologies'},
-          {text: "Open Source", link: 'engineering/open-source'}
+          {text: "Open Source", link: 'engineering/open-source'},
+          {text: "Standards", link: 'engineering/standards'}
         ]
       },
       {

--- a/handbook/engineering/standards.md
+++ b/handbook/engineering/standards.md
@@ -1,0 +1,22 @@
+---
+title: Standards
+description: 
+---
+
+# Standards
+
+To create a platform that stands the test of time, we must prioritize certain principles. One of the most important is choosing standards over proprietary abstractions and tools. This principle should guide not only [our technology choices](/engineering/technologies) but also our product design.
+
+## The Power of Standards
+
+Standards are widely adopted and maintained by a community. For example, consider the web platform standards like [HTML](https://en.wikipedia.org/wiki/HTML), [CSS](https://en.wikipedia.org/wiki/css), and [JavaScript](https://en.wikipedia.org/wiki/JavaScript). These standards are designed to be backward compatible and evolve without breaking existing implementations. This stability allows us to focus on building features that matter to our users rather than constantly updating to maintain compatibility with proprietary tools.
+
+Standards also enable [portability](https://en.wikipedia.org/wiki/Software_portability), allowing users to move freely across tools and platforms without being locked in. If our users choose to stay with Tuist, it should be because they love the product, not because they are trapped by the technology. While it is rare that a standard will not meet our needs, in such cases, we should actively contribute to the standardization process to ensure it evolves to address those needs.
+
+## Embracing Long-Term Solutions
+
+As developers, it can be tempting to adopt the latest tools that promise to solve all our problems. While these tools may offer short-term benefits like increased productivity or a better developer experience, we must remember that Tuist is a long-term, infinite game. Eventually, standards will catch up, and if they don’t, we have the opportunity to contribute to their development. For example, [OpenAPI Spec](https://swagger.io/specification/) and its tooling have evolved to compete with [GraphQL](https://graphql.org/), demonstrating how standards can advance over time.
+
+Sometimes, peeling back the layers of proprietary tools and abstractions reveals that the core functionality has improved significantly. In such cases, the additional layers may no longer be necessary. For instance, it’s perfectly acceptable to have a [#nobuild setup](https://world.hey.com/dhh/you-can-t-get-faster-than-no-build-7a44131c) for a web project, despite common misconceptions.
+
+By adhering to these principles, we ensure that our platform remains robust, adaptable, and user-focused, standing the test of time in an ever-evolving technological landscape.

--- a/handbook/engineering/technologies.md
+++ b/handbook/engineering/technologies.md
@@ -8,6 +8,14 @@ description: This document includes a list of technologies that are approved for
 When deciding a technology to use in a new project, we try to be pragmatic ensuring we prevent technology fragmentation.
 This document includes a list of technologies that are approved for use in Tuist projects along with the rationale behind each decision. If you believe a technology should be added or removed from this list, please [open a pull request](https://github.com/tuist/handbook/compare).
 
+## How we choose technologies
+
+One of our core principles in technology selection is adhering to [standards](/engineering/standards) that strike a perfect balance between simplicity and power. Many **widely adopted technologies hide underlying complexities resulting from poor foundational design.** This hidden complexity eventually surfaces, making software maintenance and evolution more challenging.
+
+A prime example of achieving simplicity through robust design is found in [Erlang](https://en.wikipedia.org/wiki/Erlang_(programming_language)) and [Elixir](https://en.wikipedia.org/wiki/Elixir_(programming_language)). These technologies provide primitives that effectively model the real world, eliminating the need for endless layers of abstractions that are common in other ecosystems.
+
+We are also mindful of cutting-edge technologies. While they often bring innovation and spark valuable debates, their premature adoption can divert us from our primary mission: building a world-class productivity platform for app developers. By focusing on well-designed, standard-based technologies, we ensure our platform remains robust, maintainable, and aligned with our long-term goals.
+
 ## Programming languages
 
 ### Swift


### PR DESCRIPTION
Our organization believes in standards as a tool to make Tuist sustain the test of time and enable portability for our users. This PR adds a page to document that within the "engineering" section.