### PR TITLE
Add a "How we work" page

### DIFF
--- a/.vitepress/config.mjs
+++ b/.vitepress/config.mjs
@@ -60,6 +60,7 @@ export default defineConfig({
         text: "People",
         items: [
           {text: "Values", link: 'people/values'},
+          {text: "How we work", link: 'people/how-we-work'}
         ]
       }
     ],

--- a/handbook/people/how-we-work.md
+++ b/handbook/people/how-we-work.md
@@ -18,7 +18,7 @@ We entrust you with the responsibility of crafting your ideal work environment a
 
 In this setup, it's important to over-communicate, doing so clearly and concisely, and to include context and expectations to minimize back-and-forth. Even though we use [Slack](https://slack.com) as a communication tool, don't expect it to be used synchronously. Avoid pings and don't expect people to respond immediately.
 
-It's also important to feel comfortable having multiple tasks in progress so that you can make progress on something else while waiting for feedback or a response.
+It's also important to feel comfortable having multiple tasks in progress, so that you can make progress on something else while waiting for feedback or a response.
 
 If a non-important conversation is turning into a long thread, move it out of Slack into [GitHub](https://github.com/tuist). **GitHub is the source of truth where important conversations and decisions should be captured** for future reference. We expect you to nudge people to move the conversation to GitHub if it's relevant.
 

--- a/handbook/people/how-we-work.md
+++ b/handbook/people/how-we-work.md
@@ -1,0 +1,43 @@
+---
+title: How we work
+description: Our approach to working together.
+---
+
+# How we work
+
+## Remote
+
+As a remote-first company, we meticulously design our processes and tools to optimize remote work. Our commitment to excellence leads us to seek out and hire top talent globally, constrained only by legal considerations, not geographical boundaries.
+
+We entrust you with the responsibility of crafting your ideal work environment and determining your most productive schedule. Our faith in your judgment is unwavering; we believe you'll make choices that best serve both your needs and the company's goals. Rest assured, we stand ready to provide whatever support you require to thrive in your role. Your success is our success, and we're dedicated to empowering you with the flexibility and resources necessary to achieve it.
+
+> [!TIP] GLOBAL INTERNET WITH A NO GLOBAL LEGAL FRAMEWORK
+> While the internet enables global hiring, legal constraints may limit our ability to employ people from certain countries. We strive to overcome these challenges, but can't guarantee employment if we lack legal representation in your location. We'll always be transparent about such limitations during the hiring process.
+
+## Communication
+
+In this setup, it's important to over-communicate, doing so clearly and concisely, and to include context and expectations to minimize back-and-forth. Even though we use [Slack](https://slack.com) as a communication tool, don't expect it to be used synchronously. Avoid pings and don't expect people to respond immediately.
+
+It's also important to feel comfortable having multiple tasks in progress so that you can make progress on something else while waiting for feedback or a response.
+
+If a non-important conversation is turning into a long thread, move it out of Slack into [GitHub](https://github.com/tuist). **GitHub is the source of truth where important conversations and decisions should be captured** for future reference. We expect you to nudge people to move the conversation to GitHub if it's relevant.
+
+## Agency
+
+We believe in giving you the agency to make decisions and take ownership of your work. **We trust you to make the right decisions and to ask for help** when you need it. We don't micromanage, but we do expect you to communicate your progress and blockers clearly and proactively.
+
+If you are unable to make decisions because you don't have enough context or because you're blocked, don't hesitate to ask for help. We're here to support you and help you grow. Look at these moments as opportunities to improve our processes, handbook, and tools to assist future team members in similar situations.
+
+You'll be informed of the priorities, and you'll be expected to make decisions based on them. If you're unsure about the priority of a task, ask for clarification.
+
+## Innovate
+
+Many organizations cargo-cult existing processes and tools without questioning their effectiveness.
+For example, [continuous integration](https://en.wikipedia.org/wiki/Continuous_integration) providers have cargo-culted proprietary YAMLs as an interface layer between them and repositories, despite the ongoing pain and frustration this causes developers.
+*What if we could do better?*
+
+We need you to think different, to challenge the status quo, and to propose improvements to our processes and tools. 
+Don't be afraid to do so.
+Share you ideas and let them be challenged by the team.
+We invested in creating an environment where innovation is possible,
+and we want you to take advantage of it.


### PR DESCRIPTION
Continuing with adding resources that might be useful to onboard team members in the future, I'm adding a page documenting how we work.