### PR TITLE
Add a new section to document support tools and practices

### DIFF
--- a/.vitepress/config.mjs
+++ b/.vitepress/config.mjs
@@ -1,5 +1,5 @@
 import { defineConfig } from 'vitepress'
-import {atom01Icon, codeBrowserIcon, heartIcon, target04Icon, cubeOutlineIcon} from "./icons.mjs";
+import {atom01Icon, codeBrowserIcon, heartIcon, target04Icon, cubeOutlineIcon, lifeBuoy02Icon} from "./icons.mjs";
 
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
@@ -61,6 +61,12 @@ export default defineConfig({
           {text: "Technologies", link: 'engineering/technologies'},
           {text: "Open Source", link: 'engineering/open-source'},
           {text: "Standards", link: 'engineering/standards'}
+        ]
+      },
+      {
+        text: `<div style="display: flex; flex-direction: row; align-items: center; gap: 7px;">Support ${lifeBuoy02Icon()}</div>`,
+        items: [
+          {text: "Process", link: 'support/process'},
         ]
       },
       {

--- a/.vitepress/icons.mjs
+++ b/.vitepress/icons.mjs
@@ -32,3 +32,11 @@ export function target04Icon(size = 15) {
 </svg>
 `
 }
+
+export function lifeBuoy02Icon(size = 15) {
+  return `<svg width="${size}" height="${size}" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M8.46445 8.46448L4.92893 4.92896M4.92893 19.0711L8.46448 15.5355M15.5355 15.5355L19.0711 19.071M19.0711 4.92891L15.5355 8.46445M22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12ZM17 12C17 14.7614 14.7614 17 12 17C9.23858 17 7 14.7614 7 12C7 9.23858 9.23858 7 12 7C14.7614 7 17 9.23858 17 12Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>
+
+`
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "grammarly.selectors": [
+        {
+            "language": "markdown",
+            "scheme": "file"
+        }
+    ]
+}

--- a/handbook/support/process.md
+++ b/handbook/support/process.md
@@ -1,0 +1,42 @@
+---
+title: Support process
+description: Learn how we provide support to developers and organizations using Tuist.
+---
+
+# Support process
+
+Developers and organizations might run into issues or have questions while using Tuist.
+When that happens, we need to ensure their input is processed promptly and the proper context is captured to understand the problem or need and prioritize it accordingly.
+This page outlines the processes that we have in place for providing the best support.
+
+## Default to GitHub
+
+By default, we use GitHub to provide support through [GitHub Issues](https://github.com/features/issues),
+and we expect developers and organizations to create issues in the repository associated with the project they are having issues with.
+Most will do so in the [tuist/tuist](https://github.com/tuist/tuist) repository to provide support,
+which takes priority over issues in other open-source repositories that we maintain.
+
+When providing support:
+
+- Ensure the issue contains all the necessary information to understand the problem or need and includes a [reproducible project](https://docs.tuist.io/contributors/issue-reporting.html#reproducible-project) and steps. If it doesn't, assign the status `Needs reproduction/response` in the Tuist GitHub project.
+- If the person is blocked, provide a workaround if possible.
+- Assign the priority based on the following criteria:
+  - **P0**: Critical issue that prevents them from using a paid feature or the tool.
+  - **P1**: Critical issue that prevents them from using the tool (no workaround exists).
+  - **P2**: Important issue that doesn't prevent them from using the tool.
+  - **P3**: Nice-to-have feature or improvement.
+
+> [!IMPORTANT] P0 ISSUES
+> P0 Issues should become an immediate priority and be worked on as soon as possible.
+
+> [!NOTE] SLACK
+> We should expect that people might use the community Slack to seek support. We should monitor the Slack channel and redirect them to GitHub Issues if they haven't already created an issue. Slack is not the best support channel to use at scale.
+
+## Priority support
+
+**Tuist Enterprise organizations** can use the cross-Slack channel to get priority support. Tickets reported through this channel get the highest priority.
+
+**Tuist Pro organizations** can use the `support@tuist.io` email to get priority support.
+We process those emails through [Intercom](https://intercom.com),
+so if you are expected to provide support, you'll have access to the Intercom inbox.
+Assign new tickets to you to signal that you are working on them.

--- a/handbook/support/process.md
+++ b/handbook/support/process.md
@@ -36,7 +36,7 @@ When providing support:
 
 **Tuist Enterprise organizations** can use the cross-Slack channel to get priority support. Tickets reported through this channel get the highest priority.
 
-**Tuist Pro organizations** can use the `support@tuist.io` email to get priority support and a cross-Slack channel.
+**Tuist Pro organizations** can use the `support@tuist.io` email to get priority support and a cross-slack channel.
 We process those emails through [Intercom](https://intercom.com),
 so if you are expected to provide support, you'll have access to the Intercom inbox.
 Assign new tickets to you to signal that you are working on them.

--- a/handbook/support/process.md
+++ b/handbook/support/process.md
@@ -36,7 +36,7 @@ When providing support:
 
 **Tuist Enterprise organizations** can use the cross-Slack channel to get priority support. Tickets reported through this channel get the highest priority.
 
-**Tuist Pro organizations** can use the `support@tuist.io` email to get priority support.
+**Tuist Pro organizations** can use the `support@tuist.io` email to get priority support and a cross-Slack channel.
 We process those emails through [Intercom](https://intercom.com),
 so if you are expected to provide support, you'll have access to the Intercom inbox.
 Assign new tickets to you to signal that you are working on them.


### PR DESCRIPTION
I'm starting to capture our processes around how we provide support so we can quickly onboard new developers with that responsibility. 