### PR TITLE
Add SOC-2 suggested code of conduct

### DIFF
--- a/.vitepress/config.mjs
+++ b/.vitepress/config.mjs
@@ -10,6 +10,20 @@ export default defineConfig({
   sitemap: {
     hostname: "https://handbook.tuist.io",
   },
+  locales: {
+    root: {
+      label: 'English',
+      lang: 'en'
+    },
+    es: {
+      label: "Español",
+      lang: "es"
+    },
+    de: {
+      label: "Deutsch",
+      lang: "es"
+    }
+  },
   head: [
     [
       "script",

--- a/handbook/de/people/code-of-conduct.md
+++ b/handbook/de/people/code-of-conduct.md
@@ -1,0 +1,88 @@
+---
+title: Verhaltenskodex
+description: Der Verhaltenskodex für die Mitarbeiter von Tuist.
+---
+
+# Verhaltenskodex
+
+- **Richtlinienverantwortlicher:** Pedro Piñera Buendía
+- **Datum des Inkrafttretens:** 26. August 2024
+
+## Zweck
+
+Das Hauptziel des Verhaltenskodex von tuist.io besteht darin, die integrativen, kollaborativen und sicheren Arbeitsbedingungen für alle Mitarbeiter von tuist.io zu fördern. Daher setzt sich tuist.io dafür ein, allen Mitarbeitern ein freundliches, sicheres und einladendes Umfeld zu bieten, unabhängig von Geschlecht, sexueller Orientierung, Fähigkeit, Herkunft, sozioökonomischem Status oder Religion (oder deren Nichtpraktizieren).
+
+Dieser Verhaltenskodex umreißt unsere Erwartungen an alle Mitarbeiter von tuist.io sowie die Konsequenzen für inakzeptables Verhalten.
+
+## Umfang
+
+Der Verhaltenskodex gilt für alle Mitarbeiter von tuist.io. Dazu gehören Vollzeit- und Teilzeitkräfte sowie Vertragspersonal auf jeder Dienstaltersstufe. Der Verhaltenskodex ist bei allen beruflichen Tätigkeiten und Veranstaltungen einzuhalten, einschließlich, aber nicht beschränkt auf die Geschäftszeiten im Büro von tuist.io, während außergeschäftlicher Aktivitäten und Veranstaltungen im Zusammenhang mit tuist.io, während der Teilnahme an Konferenzen und anderen beruflichen Veranstaltungen im Namen von tuist.io und während Fernarbeit und der Kommunikation mit anderen Mitarbeitern über Ressourcen von tuist.io.
+
+Wir erwarten von allen Mitarbeitern von tuist.io, dass sie sich in allen geschäftlichen Angelegenheiten – online und persönlich – sowie bei der gesamten persönlichen Geschäftskommunikation mit Kunden und Mitarbeitern von tuist.io an diesen Verhaltenskodex halten.
+
+Dieser Verhaltenskodex gilt auch für inakzeptables Verhalten, das außerhalb der geschäftlichen Aktivitäten erfolgt, wenn solches Verhalten das Potenzial hat, die Sicherheit und das Wohlbefinden von Mitarbeitern und Kunden von tuist.io nachteilig zu beeinflussen.
+
+## Kultur und Teilhabe
+
+Ein zusätzliches Ziel dieses Verhaltenskodex ist es, die offene Teilhabe zu erhöhen, indem die Teilnehmer ermutigt werden, die Beziehungen zwischen unseren Handlungen und ihren Auswirkungen innerhalb der Kultur von tuist.io zu erkennen.
+
+**Seien Sie freundlich.** Wir sind bestrebt, ein Unternehmen zu sein, das Menschen aller Hintergründe und Identitäten willkommen heißt und unterstützt. Und zwar unabhängig von Abstammung, Ethnie, Kultur, nationaler Herkunft, Hautfarbe, Einwanderungsstatus, sozialer und wirtschaftlicher Klasse, Bildungsniveau, sexueller Orientierung, Geschlechtsidentität und -ausdruck, Alter, Größe, Familienstatus, politischer Überzeugung, Religion sowie geistiger und physischer Fähigkeiten.
+**Seien Sie rücksichtsvoll.** Ihre Arbeit bei tuist.io wird von anderen Menschen genutzt, und Sie wiederum sind von der Arbeit anderer abhängig. Jede Entscheidung, die Sie treffen, wirkt sich auf Benutzer und Kollegen aus, und Sie sollten diese Konsequenzen bei Ihren Entscheidungen berücksichtigen.
+**Seien Sie höflich.** Nicht alle von uns werden immer einer Meinung sein, aber Meinungsverschiedenheiten sind keine Entschuldigung für schlechtes Benehmen und schlechte Manieren. Wir mögen alle ab und zu frustriert sein, aber wir dürfen nicht zulassen, dass diese Frustration zu persönlichen Angriffen führt. Es ist wichtig, sich daran zu erinnern, dass ein Unternehmen, in dem sich Menschen unwohl oder bedroht fühlen, weder produktiv noch angenehm ist. Die Mitarbeiter von tuist.io sollten sich im Umgang mit anderen Mitarbeitern sowie mit nicht bei tuist.io angestellten Personen stets respektvoll verhalten.
+
+## Akzeptables und erwartetes Verhalten
+
+Die folgenden Verhaltensweisen werden von allen Mitarbeitern von tuist.io erwartet und verlangt:
+
+- Nehmen Sie authentisch und aktiv teil. Auf diese Weise tragen Sie zur Gesundheit und Langlebigkeit von tuist.io bei.
+- Drücken Sie in Ihren Formulierungen und Handlungen jederzeit Rücksicht und Respekt aus.
+- Ziehen Sie die Zusammenarbeit dem Konflikt vor.
+- Unterlassen Sie erniedrigendes, diskriminierendes oder belästigendes Verhalten und ebensolche Formulierungen.
+- Achten Sie auf Ihre Umgebung und auf Ihre Kollegen. Benachrichtigen Sie die Führungskräfte von tuist.io, wenn Sie eine gefährliche Situation, jemanden in Not oder Verstöße gegen diesen Verhaltenskodex bemerken, auch wenn diese belanglos erscheinen.
+- Denken Sie daran, dass Veranstaltungen von tuist.io mit Mitgliedern der Öffentlichkeit und Kunden von tuist.io stattfinden können. Bitte verhalten Sie sich gegenüber allen Teilnehmern dieser Veranstaltungen jederzeit respektvoll.
+
+## Inakzeptables Verhalten
+
+Die folgenden Verhaltensweisen gelten als Belästigung und sind innerhalb unserer Gemeinschaft inakzeptabel:
+
+- Gewalt, Gewaltandrohung oder gewalttätige Äußerungen gegen eine andere Person
+- Sexistische, rassistische, homophobe, transphobe, ableistische oder auf andere Weise diskriminierende Witze und Sprache
+- Veröffentlichen oder Zurschaustellen von sexuell eindeutigem oder gewalttätigem Material
+- Veröffentlichung oder Androhung der Veröffentlichung von persönlichen Informationen anderer Personen („Doxing“)
+- Persönliche Beleidigungen, insbesondere in Bezug auf Geschlecht, sexuelle Orientierung, Herkunft, Religion oder Behinderung
+- Unangemessene Fotografien oder Aufnahmen
+- Unangemessener physischer Kontakt. Sie müssen die Zustimmung von jemandem haben, bevor Sie ihn in irgendeiner Weise berühren.
+- Unerwünschte sexuelle Aufmerksamkeit. Dazu gehören sexualisierte Kommentare oder Witze; unangemessenes Berühren, Anfassen und unerwünschte sexuelle Avancen.
+- Vorsätzliche Einschüchterung, Stalking oder Verfolgung (online oder persönlich)
+- Befürworten oder Ermutigen eines der oben genannten Verhaltensweisen
+- Wiederholte Belästigung anderer. Generell gilt: Wenn jemand darum bittet, dass Sie aufhören, dann hören Sie auf.
+- Sonstiges Verhalten, das in einem beruflichen Umfeld als unangemessen angesehen werden könnte
+
+## Richtlinie für Waffen
+
+Bei Veranstaltungen von tuist.io, an Bürostandorten oder in anderen Räumen, die in den Geltungsbereich dieses Verhaltenskodexes fallen, sind Waffen nicht erlaubt. Zu den Waffen gehören unter anderem Schusswaffen, Sprengstoffe (einschließlich Feuerwerkskörper) und große Messer, wie sie für die Jagd oder zur Zurschaustellung verwendet werden, sowie alle anderen Gegenstände, die dazu verwendet werden, andere zu verletzen oder ihnen Schaden zuzufügen.
+
+Jeder, der im Besitz eines dieser Gegenstände gesehen wird, wird aufgefordert, das Gelände unverzüglich zu verlassen und wird mit Strafmaßnahmen bis hin zur Kündigung und Einschaltung der Strafverfolgungsbehörden belegt. Von den Mitarbeitern von tuist.io wird ferner erwartet, dass sie alle staatlichen und lokalen Gesetze in dieser Angelegenheit einhalten.
+
+## Folgen inakzeptablen Verhaltens
+
+Inakzeptables Verhalten von Mitarbeitern von tuist.io, einschließlich solcher mit Entscheidungsbefugnis, wird nicht toleriert.
+
+Von jedem, der aufgefordert wird, inakzeptables Verhalten zu unterbinden, wird erwartet, dass er sich unverzüglich daran hält.
+
+Wenn ein Mitarbeiter sich inakzeptabel verhält, kann die Führungsebene von tuist.io alle als angemessen erachteten Maßnahmen ergreifen, bis hin zur Freistellung oder Kündigung.
+
+## Meldung von Verstößen
+
+Wenn Sie inakzeptablem Verhalten ausgesetzt sind, Zeuge von inakzeptablem Verhalten werden oder andere Bedenken haben, benachrichtigen Sie bitte so schnell wie möglich eine geeignete Führungskraft von tuist.io.
+
+Es gilt als Verstoß gegen diese Richtlinie, Vergeltungsmaßnahmen gegen eine Person zu ergreifen, die eine Beschwerde über inakzeptables Verhalten einreicht, oder gegen eine Person, die an der Untersuchung eines solchen Vorwurfs beteiligt ist (einschließlich der Aussage als Zeuge). Jede Vergeltung oder Einschüchterung kann mit Strafmaßnahmen bis hin zur Kündigung belegt werden.
+
+## Disziplinarische Maßnahmen
+
+Gegen Mitarbeiter, die gegen diese Richtlinie verstoßen, können im Verhältnis zu ihrem Verstoß disziplinarische Maßnahmen ergriffen werden. Die Führungsebene von tuist.io bestimmt, wie schwerwiegend der Verstoß eines Mitarbeiters ist, und ergreift die entsprechenden Maßnahmen.
+
+## Versionsverlauf
+
+Die Versionsgeschichte dieses Dokuments ist im [Handbook](https://github.com/tuist/handbook)-Repository von Tuist zu finden.
+

--- a/handbook/de/people/code-of-conduct.md
+++ b/handbook/de/people/code-of-conduct.md
@@ -10,36 +10,36 @@ description: Der Verhaltenskodex für die Mitarbeiter von Tuist.
 
 ## Zweck
 
-Das Hauptziel des Verhaltenskodex von tuist.io besteht darin, die integrativen, kollaborativen und sicheren Arbeitsbedingungen für alle Mitarbeiter von tuist.io zu fördern. Daher setzt sich tuist.io dafür ein, allen Mitarbeitern ein freundliches, sicheres und einladendes Umfeld zu bieten, unabhängig von Geschlecht, sexueller Orientierung, Fähigkeit, Herkunft, sozioökonomischem Status oder Religion (oder deren Nichtpraktizieren).
+Das Hauptziel des Verhaltenskodex von Tuist besteht darin, die integrativen, kollaborativen und sicheren Arbeitsbedingungen für alle Mitarbeiter von Tuist zu fördern. Daher setzt sich Tuist dafür ein, allen Mitarbeitern ein freundliches, sicheres und einladendes Umfeld zu bieten, unabhängig von Geschlecht, sexueller Orientierung, Fähigkeit, Herkunft, sozioökonomischem Status oder Religion (oder deren Nichtpraktizieren).
 
-Dieser Verhaltenskodex umreißt unsere Erwartungen an alle Mitarbeiter von tuist.io sowie die Konsequenzen für inakzeptables Verhalten.
+Dieser Verhaltenskodex umreißt unsere Erwartungen an alle Mitarbeiter von Tuist sowie die Konsequenzen für inakzeptables Verhalten.
 
 ## Umfang
 
-Der Verhaltenskodex gilt für alle Mitarbeiter von tuist.io. Dazu gehören Vollzeit- und Teilzeitkräfte sowie Vertragspersonal auf jeder Dienstaltersstufe. Der Verhaltenskodex ist bei allen beruflichen Tätigkeiten und Veranstaltungen einzuhalten, einschließlich, aber nicht beschränkt auf die Geschäftszeiten im Büro von tuist.io, während außergeschäftlicher Aktivitäten und Veranstaltungen im Zusammenhang mit tuist.io, während der Teilnahme an Konferenzen und anderen beruflichen Veranstaltungen im Namen von tuist.io und während Fernarbeit und der Kommunikation mit anderen Mitarbeitern über Ressourcen von tuist.io.
+Der Verhaltenskodex gilt für alle Mitarbeiter von Tuist. Dazu gehören Vollzeit- und Teilzeitkräfte sowie Vertragspersonal auf jeder Dienstaltersstufe. Der Verhaltenskodex ist bei allen beruflichen Tätigkeiten und Veranstaltungen einzuhalten, einschließlich, aber nicht beschränkt auf die Geschäftszeiten im Büro von Tuist, während außergeschäftlicher Aktivitäten und Veranstaltungen im Zusammenhang mit Tuist, während der Teilnahme an Konferenzen und anderen beruflichen Veranstaltungen im Namen von Tuist und während Fernarbeit und der Kommunikation mit anderen Mitarbeitern über Ressourcen von Tuist.
 
-Wir erwarten von allen Mitarbeitern von tuist.io, dass sie sich in allen geschäftlichen Angelegenheiten – online und persönlich – sowie bei der gesamten persönlichen Geschäftskommunikation mit Kunden und Mitarbeitern von tuist.io an diesen Verhaltenskodex halten.
+Wir erwarten von allen Mitarbeitern von Tuist, dass sie sich in allen geschäftlichen Angelegenheiten – online und persönlich – sowie bei der gesamten persönlichen Geschäftskommunikation mit Kunden und Mitarbeitern von Tuist an diesen Verhaltenskodex halten.
 
-Dieser Verhaltenskodex gilt auch für inakzeptables Verhalten, das außerhalb der geschäftlichen Aktivitäten erfolgt, wenn solches Verhalten das Potenzial hat, die Sicherheit und das Wohlbefinden von Mitarbeitern und Kunden von tuist.io nachteilig zu beeinflussen.
+Dieser Verhaltenskodex gilt auch für inakzeptables Verhalten, das außerhalb der geschäftlichen Aktivitäten erfolgt, wenn solches Verhalten das Potenzial hat, die Sicherheit und das Wohlbefinden von Mitarbeitern und Kunden von Tuist nachteilig zu beeinflussen.
 
 ## Kultur und Teilhabe
 
-Ein zusätzliches Ziel dieses Verhaltenskodex ist es, die offene Teilhabe zu erhöhen, indem die Teilnehmer ermutigt werden, die Beziehungen zwischen unseren Handlungen und ihren Auswirkungen innerhalb der Kultur von tuist.io zu erkennen.
+Ein zusätzliches Ziel dieses Verhaltenskodex ist es, die offene Teilhabe zu erhöhen, indem die Teilnehmer ermutigt werden, die Beziehungen zwischen unseren Handlungen und ihren Auswirkungen innerhalb der Kultur von Tuist zu erkennen.
 
 **Seien Sie freundlich.** Wir sind bestrebt, ein Unternehmen zu sein, das Menschen aller Hintergründe und Identitäten willkommen heißt und unterstützt. Und zwar unabhängig von Abstammung, Ethnie, Kultur, nationaler Herkunft, Hautfarbe, Einwanderungsstatus, sozialer und wirtschaftlicher Klasse, Bildungsniveau, sexueller Orientierung, Geschlechtsidentität und -ausdruck, Alter, Größe, Familienstatus, politischer Überzeugung, Religion sowie geistiger und physischer Fähigkeiten.
-**Seien Sie rücksichtsvoll.** Ihre Arbeit bei tuist.io wird von anderen Menschen genutzt, und Sie wiederum sind von der Arbeit anderer abhängig. Jede Entscheidung, die Sie treffen, wirkt sich auf Benutzer und Kollegen aus, und Sie sollten diese Konsequenzen bei Ihren Entscheidungen berücksichtigen.
-**Seien Sie höflich.** Nicht alle von uns werden immer einer Meinung sein, aber Meinungsverschiedenheiten sind keine Entschuldigung für schlechtes Benehmen und schlechte Manieren. Wir mögen alle ab und zu frustriert sein, aber wir dürfen nicht zulassen, dass diese Frustration zu persönlichen Angriffen führt. Es ist wichtig, sich daran zu erinnern, dass ein Unternehmen, in dem sich Menschen unwohl oder bedroht fühlen, weder produktiv noch angenehm ist. Die Mitarbeiter von tuist.io sollten sich im Umgang mit anderen Mitarbeitern sowie mit nicht bei tuist.io angestellten Personen stets respektvoll verhalten.
+**Seien Sie rücksichtsvoll.** Ihre Arbeit bei Tuist wird von anderen Menschen genutzt, und Sie wiederum sind von der Arbeit anderer abhängig. Jede Entscheidung, die Sie treffen, wirkt sich auf Benutzer und Kollegen aus, und Sie sollten diese Konsequenzen bei Ihren Entscheidungen berücksichtigen.
+**Seien Sie höflich.** Nicht alle von uns werden immer einer Meinung sein, aber Meinungsverschiedenheiten sind keine Entschuldigung für schlechtes Benehmen und schlechte Manieren. Wir mögen alle ab und zu frustriert sein, aber wir dürfen nicht zulassen, dass diese Frustration zu persönlichen Angriffen führt. Es ist wichtig, sich daran zu erinnern, dass ein Unternehmen, in dem sich Menschen unwohl oder bedroht fühlen, weder produktiv noch angenehm ist. Die Mitarbeiter von Tuist sollten sich im Umgang mit anderen Mitarbeitern sowie mit nicht bei Tuist angestellten Personen stets respektvoll verhalten.
 
 ## Akzeptables und erwartetes Verhalten
 
-Die folgenden Verhaltensweisen werden von allen Mitarbeitern von tuist.io erwartet und verlangt:
+Die folgenden Verhaltensweisen werden von allen Mitarbeitern von Tuist erwartet und verlangt:
 
-- Nehmen Sie authentisch und aktiv teil. Auf diese Weise tragen Sie zur Gesundheit und Langlebigkeit von tuist.io bei.
+- Nehmen Sie authentisch und aktiv teil. Auf diese Weise tragen Sie zur Gesundheit und Langlebigkeit von Tuist bei.
 - Drücken Sie in Ihren Formulierungen und Handlungen jederzeit Rücksicht und Respekt aus.
 - Ziehen Sie die Zusammenarbeit dem Konflikt vor.
 - Unterlassen Sie erniedrigendes, diskriminierendes oder belästigendes Verhalten und ebensolche Formulierungen.
-- Achten Sie auf Ihre Umgebung und auf Ihre Kollegen. Benachrichtigen Sie die Führungskräfte von tuist.io, wenn Sie eine gefährliche Situation, jemanden in Not oder Verstöße gegen diesen Verhaltenskodex bemerken, auch wenn diese belanglos erscheinen.
-- Denken Sie daran, dass Veranstaltungen von tuist.io mit Mitgliedern der Öffentlichkeit und Kunden von tuist.io stattfinden können. Bitte verhalten Sie sich gegenüber allen Teilnehmern dieser Veranstaltungen jederzeit respektvoll.
+- Achten Sie auf Ihre Umgebung und auf Ihre Kollegen. Benachrichtigen Sie die Führungskräfte von Tuist, wenn Sie eine gefährliche Situation, jemanden in Not oder Verstöße gegen diesen Verhaltenskodex bemerken, auch wenn diese belanglos erscheinen.
+- Denken Sie daran, dass Veranstaltungen von Tuist mit Mitgliedern der Öffentlichkeit und Kunden von Tuist stattfinden können. Bitte verhalten Sie sich gegenüber allen Teilnehmern dieser Veranstaltungen jederzeit respektvoll.
 
 ## Inakzeptables Verhalten
 
@@ -60,27 +60,27 @@ Die folgenden Verhaltensweisen gelten als Belästigung und sind innerhalb unsere
 
 ## Richtlinie für Waffen
 
-Bei Veranstaltungen von tuist.io, an Bürostandorten oder in anderen Räumen, die in den Geltungsbereich dieses Verhaltenskodexes fallen, sind Waffen nicht erlaubt. Zu den Waffen gehören unter anderem Schusswaffen, Sprengstoffe (einschließlich Feuerwerkskörper) und große Messer, wie sie für die Jagd oder zur Zurschaustellung verwendet werden, sowie alle anderen Gegenstände, die dazu verwendet werden, andere zu verletzen oder ihnen Schaden zuzufügen.
+Bei Veranstaltungen von Tuist, an Bürostandorten oder in anderen Räumen, die in den Geltungsbereich dieses Verhaltenskodexes fallen, sind Waffen nicht erlaubt. Zu den Waffen gehören unter anderem Schusswaffen, Sprengstoffe (einschließlich Feuerwerkskörper) und große Messer, wie sie für die Jagd oder zur Zurschaustellung verwendet werden, sowie alle anderen Gegenstände, die dazu verwendet werden, andere zu verletzen oder ihnen Schaden zuzufügen.
 
-Jeder, der im Besitz eines dieser Gegenstände gesehen wird, wird aufgefordert, das Gelände unverzüglich zu verlassen und wird mit Strafmaßnahmen bis hin zur Kündigung und Einschaltung der Strafverfolgungsbehörden belegt. Von den Mitarbeitern von tuist.io wird ferner erwartet, dass sie alle staatlichen und lokalen Gesetze in dieser Angelegenheit einhalten.
+Jeder, der im Besitz eines dieser Gegenstände gesehen wird, wird aufgefordert, das Gelände unverzüglich zu verlassen und wird mit Strafmaßnahmen bis hin zur Kündigung und Einschaltung der Strafverfolgungsbehörden belegt. Von den Mitarbeitern von Tuist wird ferner erwartet, dass sie alle staatlichen und lokalen Gesetze in dieser Angelegenheit einhalten.
 
 ## Folgen inakzeptablen Verhaltens
 
-Inakzeptables Verhalten von Mitarbeitern von tuist.io, einschließlich solcher mit Entscheidungsbefugnis, wird nicht toleriert.
+Inakzeptables Verhalten von Mitarbeitern von Tuist, einschließlich solcher mit Entscheidungsbefugnis, wird nicht toleriert.
 
 Von jedem, der aufgefordert wird, inakzeptables Verhalten zu unterbinden, wird erwartet, dass er sich unverzüglich daran hält.
 
-Wenn ein Mitarbeiter sich inakzeptabel verhält, kann die Führungsebene von tuist.io alle als angemessen erachteten Maßnahmen ergreifen, bis hin zur Freistellung oder Kündigung.
+Wenn ein Mitarbeiter sich inakzeptabel verhält, kann die Führungsebene von Tuist alle als angemessen erachteten Maßnahmen ergreifen, bis hin zur Freistellung oder Kündigung.
 
 ## Meldung von Verstößen
 
-Wenn Sie inakzeptablem Verhalten ausgesetzt sind, Zeuge von inakzeptablem Verhalten werden oder andere Bedenken haben, benachrichtigen Sie bitte so schnell wie möglich eine geeignete Führungskraft von tuist.io.
+Wenn Sie inakzeptablem Verhalten ausgesetzt sind, Zeuge von inakzeptablem Verhalten werden oder andere Bedenken haben, benachrichtigen Sie bitte so schnell wie möglich eine geeignete Führungskraft von Tuist.
 
 Es gilt als Verstoß gegen diese Richtlinie, Vergeltungsmaßnahmen gegen eine Person zu ergreifen, die eine Beschwerde über inakzeptables Verhalten einreicht, oder gegen eine Person, die an der Untersuchung eines solchen Vorwurfs beteiligt ist (einschließlich der Aussage als Zeuge). Jede Vergeltung oder Einschüchterung kann mit Strafmaßnahmen bis hin zur Kündigung belegt werden.
 
 ## Disziplinarische Maßnahmen
 
-Gegen Mitarbeiter, die gegen diese Richtlinie verstoßen, können im Verhältnis zu ihrem Verstoß disziplinarische Maßnahmen ergriffen werden. Die Führungsebene von tuist.io bestimmt, wie schwerwiegend der Verstoß eines Mitarbeiters ist, und ergreift die entsprechenden Maßnahmen.
+Gegen Mitarbeiter, die gegen diese Richtlinie verstoßen, können im Verhältnis zu ihrem Verstoß disziplinarische Maßnahmen ergriffen werden. Die Führungsebene von Tuist bestimmt, wie schwerwiegend der Verstoß eines Mitarbeiters ist, und ergreift die entsprechenden Maßnahmen.
 
 ## Versionsverlauf
 

--- a/handbook/es/people/code-of-conduct.md
+++ b/handbook/es/people/code-of-conduct.md
@@ -133,8 +133,3 @@ medidas correspondientes.
 ## Historial de versiones
 
 El historial de versiones de este documento se puede encontrar en el repository [handbook](https://github.com/tuist/handbook) de Tuist.
-
-
-
-
-

--- a/handbook/es/people/code-of-conduct.md
+++ b/handbook/es/people/code-of-conduct.md
@@ -1,0 +1,140 @@
+---
+title: Codigo de conducta
+description: El código de conducta para los empleados de Tuist.
+---
+
+# Código de conducta
+
+- **Propietario de la política:** Pedro Piñera Buendía
+- **Fecha de entrada en vigencia:** 26 de agosto de 2024
+
+## Objetivo
+
+El objetivo principal del Código de conducta de Tuist es fomentar condiciones laborales inclusivas,
+colaborativas y seguras para todo el personal de Tuist. Como tal, Tuist se compromete a proporcionar
+un entorno amigable, seguro y acogedor para todo el personal, independientemente del género, la
+orientación sexual, la capacidad, el origen étnico, el estado socioeconómico o la religión (o la falta de ellos).
+
+Este código de conducta describe nuestras expectativas para todo el personal de Tuist, así como las
+consecuencias del comportamiento inaceptable.
+
+## Alcance
+
+El Código de conducta se aplica a todo el personal de Tuist. Esto incluye personal a tiempo completo, a
+tiempo parcial y contratista empleados en todos los niveles de antigüedad. El Código de conducta debe
+mantenerse durante todas las funciones y eventos profesionales, incluidos, entre otros, los horarios
+comerciales en la oficina de Tuist durante las actividades y los eventos extracurriculares relacionados con
+Tuist, mientras asiste a conferencias y otros eventos profesionales en nombre de Tuist,y mientras
+trabaja de forma remota y se comunica con los recursos de Tuist con otro personal.
+
+Esperamos que todo el personal de Tuist acate este Código de conducta en todos los asuntos
+comerciales, en línea y en persona, así como en todas las comunicaciones individuales con los clientes y el
+personal que realiza negocios deTuist.
+
+Este Código de conducta también se aplica al comportamiento inaceptable que ocurre fuera del alcance de
+las actividades comerciales cuando dicho comportamiento pudiese afectar negativamente la seguridad y el
+bienestar del personal y los clientes de Tuist.
+
+## Cultura y ciudadanía
+
+Un objetivo complementario de este Código de conducta es aumentar la ciudadanía abierta y alentar a los
+participantes a reconocer las relaciones entre nuestras acciones y sus efectos dentro de la cultura de
+Tuist.
+
+**Les damos la bienvenida.** Nos esforzamos por ser una empresa que da la bienvenida y apoya a personas
+de todos los orígenes e identidades. Esto incluye, entre otros, a miembros de cualquier raza, origen étnico,
+cultura, nacionalidad, color, estado migratorio, clase social y económica, nivel educativo, orientación
+sexual, identidad y expresión de género, edad, tamaño, estado familiar, creencia política, religión y
+capacidad mental y física.
+
+**Tenga consideración.** Otras personas en Tuist utilizarán su trabajo y, a su vez, usted dependerá del
+trabajo de los demás. Cualquier decisión que tome afectará a los usuarios y colegas, y debe tener en
+cuenta esas consecuencias al tomar decisiones.
+
+**Muestre respeto.** No todos estaremos de acuerdo todo el tiempo, pero el desacuerdo no es excusa para el
+mal comportamiento y los malos modales. Todos podemos experimentar cierta frustración de vez en
+cuando, pero no podemos permitir que esa frustración se convierta en un ataque personal. Es importante
+recordar que una empresa en la que la gente se siente incómoda o amenazada no es productiva ni
+agradable. El personal de Tuist siempre deberá ser respetuoso al tratar a otro miembro del personal,
+como también con personas que no trabajen en Tuist
+
+## Comportamiento aceptable y esperado
+
+Se esperan y solicitan los siguientes comportamientos de todo el personal de Tuist:
+
+- Participe de manera auténtica y activa. Al hacerlo, contribuye a la salud y longevidad de Tuist.
+- Muestre consideración y respeto en su discurso y sus acciones en todo momento.
+- Intente mostrar colaboración antes que conflicto.
+- Absténgase de comportamientos y discursos degradantes, discriminatorios o de acoso.
+- Sea consciente de su entorno y de sus colegas. Alerte a los líderes de Tuist si observa una
+situación peligrosa, alguien en peligro o infracciones de este Código de conducta, incluso si parecen
+intrascendentes.
+- Recuerde que los eventos de Tuist pueden compartirse con miembros del público y con los clientes
+de Tuist; muestre respeto con todos los patrocinadores de estas sedes en todo momento
+
+## Comportamiento inaceptable
+
+Los siguientes comportamientos se consideran acoso y son inaceptables dentro de nuestra comunidad:
+- Violencia, amenazas de violencia o lenguaje violento dirigido contra otra persona
+- Chistes y lenguaje sexista, racista, homofóbico, transfóbico, capacitista o discriminatorio
+- Publicar o mostrar material sexualmente explícito o violento
+- Publicar o amenazar con publicar información de identificación personal de otras personas ("doxing")
+- Insultos personales, especialmente los relacionados con el género, la orientación sexual, la raza, la
+- religión o la discapacidad
+- Fotografía o grabación inapropiadas
+- Contacto físico inapropiado. Debería tener el consentimiento de alguien antes de tocarlo de cualquier
+manera.
+- Atención sexual no deseada. Esto incluye comentarios o bromas sexualizados, toques inapropiados,
+groping y avances sexuales no deseados
+- Intimidación deliberada, acecho o seguimiento (en línea o en persona)
+- Abogar cualquiera de los comportamientos anteriores o recomendarlos
+- Acoso reiterado a los demás. En general, si alguien le pide que se detenga, entonces deténgase
+- Toda conducta que podría considerarse razonablemente inapropiada en un entorno profesional
+
+## Política de armas
+
+No se permitirán armas en los eventos de Tuist, en las oficinas ni en otros espacios contemplados en
+este Código de conducta. Las armas incluyen, entre otras cosas, pistolas, explosivos (incluidos los fuegos
+artificiales) y cuchillos grandes, como los que se usan para cazar o exhibir, así como cualquier otro artículo
+que se use con el propósito de causar lesiones o daño a otros.
+
+A cualquier persona que se vea en posesión de uno de estos artículos se le pedirá que se retire de
+inmediato y será pasible de medidas disciplinarias que pueden incluir el despido y la participación de las
+autoridades encargadas de hacer cumplir la ley. Además, se espera que el personal de Tuist cumpla con
+todas las leyes estatales y locales sobre este asunto.
+
+## Consecuencias de un comportamiento inaceptable
+
+El comportamiento inaceptable de cualquier miembro del personal de Tuist, incluidos aquellos con
+autoridad para la toma de decisiones, no se tolerará.
+
+Se espera que cualquier persona a la que se le pida que detenga un comportamiento inaceptable lo haga
+de inmediato.
+
+Si un miembro del personal tiene un comportamiento inaceptable, la dirección de Tuist puede tomar las
+medidas que considere oportunas, lo que incluye la suspensión o el despido.
+
+## Reportar infracciones
+
+Si sufre de un comportamiento inaceptable o es testigo de ello, o tiene alguna otra inquietud, notifique al
+miembro que corresponda de la dirección de Tuist lo antes posible.
+
+Es una infracción de esta política tomar represalias contra cualquier persona que presente una denuncia
+de comportamiento inaceptable o contra cualquier persona que participe en la investigación (incluido actuar
+como testigo) de cualquier alegación de este tipo. Cualquier represalia o intimidación puede estar sujeta a
+medidas disciplinarias que pueden incluir el despido.
+
+## Medidas disciplinarias
+
+Los empleados que infrinjan esta política pueden enfrentar consecuencias disciplinarias en proporción a su
+infracción. La gerencia de Tuist determinará cuán grave es la infracción del empleado y tomará las
+medidas correspondientes.
+
+## Historial de versiones
+
+El historial de versiones de este documento se puede encontrar en el repository [handbook](https://github.com/tuist/handbook) de Tuist.
+
+
+
+
+

--- a/handbook/people/code-of-conduct.md
+++ b/handbook/people/code-of-conduct.md
@@ -1,144 +1,82 @@
 ---
 title: Code of conduct
-description: The code of conduct for the Tuist community and company.
+description: The code of conduct for the Tuist staff.
 ---
 
 # Code of conduct
 
-## Our pledge
+- **Policy Owner:** Pedro Piñera Buendía
+- **Effective Date:** 26th August, 2024
 
-We as members, contributors, and leaders pledge to make participation in our
-community a harassment-free experience for everyone, regardless of age, body
-size, visible or invisible disability, ethnicity, sex characteristics, gender
-identity and expression, level of experience, education, socio-economic status,
-nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+## Purpose 
 
-We pledge to act and interact in ways that contribute to an open, welcoming,
-diverse, inclusive, and healthy community.
-
-## Our standards
-
-Examples of behavior that contributes to a positive environment for our
-community include:
-
-* Demonstrating empathy and kindness toward other people
-* Being respectful of differing opinions, viewpoints, and experiences
-* Giving and gracefully accepting constructive feedback
-* Accepting responsibility and apologizing to those affected by our mistakes,
-  and learning from the experience
-* Focusing on what is best not just for us as individuals, but for the
-  overall community
-
-Examples of unacceptable behavior include:
-
-* The use of sexualized language or imagery, and sexual attention or
-  advances of any kind
-* Trolling, insulting or derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or email
-  address, without their explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
-  professional setting
-
-## No solicitation
-
-The following are not allowed within any community space without prior permission 
-from the community moderators:
-
-- Pitching of a business, product, or service (outside of the introductions channel). Keep it non spammy!
-- Trying to hire the Tuist core team to work on your thing. We need them to build our thing.
-- Market or competitor research. This is just annoying.
-- Encouraging a fork of the main Tuist project or promoting / soliciting people to build a service that competes directly with us. You may be able to do some of this legally, but if it's successful it would harm our project's performance. So, it's not in the project's interest to provide a place to promote something like this. If you want to partner, email sales at our company.com so we can work something out.
-
-It's feasible that a community member may do something outside of the list above that we've not foreseen which isn't in the project's best interest. We will handle these cases carefully when they come up and will edit these guidelines accordingly.
-
-If you're unsure, contact the community moderators via contact@tuist.io.
-
-## Enforcement responsibilities
-
-Community leaders are responsible for clarifying and enforcing our standards of
-acceptable behavior and will take appropriate and fair corrective action in
-response to any behavior that they deem inappropriate, threatening, offensive,
-or harmful.
-
-Community leaders have the right and responsibility to remove, edit, or reject
-comments, commits, code, wiki edits, issues, and other contributions that are
-not aligned to this Code of conduct, and will communicate reasons for moderation
-decisions when appropriate.
+The primary goal of Tuist’s Code of Conduct is to foster inclusive, collaborative and safe working conditions for all Tuist staff. As such, Tuist is committed to providing a friendly, safe and welcoming environment for all staff, regardless of gender, sexual orientation, ability, ethnicity, socioeconomic status, or religion (or lack thereof).
+This code of conduct outlines our expectations for all Tuist staff, as well as the consequences for unacceptable behavior.
 
 ## Scope
 
-This Code of conduct applies within all community spaces, and also applies when
-an individual is officially representing the community in public spaces.
-Examples of representing our community include using an official e-mail address,
-posting via an official social media account, or acting as an appointed
-representative at an online or offline event.
+The Code of Conduct applies to all Tuist staff. This includes full-time, part-time and contractor staff employed at every seniority level. The Code of Conduct is to be upheld during all professional functions and events, including but not limited to business hours at the Tuist office, during Tuist-related extracurricular activities and events, while attending conferences and other professional events on behalf of Tuist, and while working remotely and communicating on Tuist resources with other staff.
+We expect all Tuist staff to abide by this Code of Conduct in all business matters -- online and in-person -- as well as in all one-on-one communications with customers and staff pertaining to Tuist business.
+This Code of Conduct also applies to unacceptable behavior occurring outside the scope of business activities when such behavior has the potential to adversely affect the safety and well-being of Tuist staff and clients.
 
-## Enforcement
+## Culture and Citizenship
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at
-contact@tuist.io.
-All complaints will be reviewed and investigated promptly and fairly.
+A supplemental goal of this Code of Conduct is to increase open citizenship by encouraging participants to recognize the relationships between our actions and their effects within Tuist culture.
 
-All community leaders are obligated to respect the privacy and security of the
-reporter of any incident.
+**Be welcoming.** We strive to be a company that welcomes and supports people of all backgrounds and identities. This includes, but is not limited to members of any race, ethnicity, culture, national origin, color, immigration status, social and economic class, educational level, sexual orientation, gender identity and expression, age, size, family status, political belief, religion, and mental and physical ability.
 
-## Enforcement guidelines
+**Be considerate.** Your work at Tuist will be used by other people, and you in turn will depend on the work of others. Any decision you take will affect users and colleagues, and you should take those consequences into account when making decisions.
 
-Community leaders will follow these community impact guidelines in determining
-the consequences for any action they deem in violation of this Code of conduct:
+**Be respectful.** Not all of us will agree all the time, but disagreement is no excuse for poor behavior and poor manners. We might all experience some frustration now and then, but we cannot allow that frustration to turn into a personal attack. It’s important to remember that a company where people feel uncomfortable or threatened is neither productive nor pleasant. Tuist staff should always be respectful when dealing with other personnel as well as with people outside of Tuist employment.
 
-### 1. Correction
+## Acceptable and Expected Behavior
 
-**Community Impact**: Use of inappropriate language or other behavior deemed
-unprofessional or unwelcome in the community.
+The following behaviors are expected and requested of all Tuist staff:
+- Participate in an authentic and active way. In doing so, you contribute to the health and longevity of Tuist.
+- Exercise consideration and respect in your speech and actions at all times.
+- Attempt collaboration before conflict.
+- Refrain from demeaning, discriminatory, or harassing behavior and speech.
+- Be mindful of your surroundings and of your fellow participants. Alert Tuist leaders if you notice a dangerous - situation, someone in distress, or violations of this Code of Conduct, even if they seem inconsequential.
+- Remember that Tuist events may be shared with members of the public and Tuist customers; please be respectful to all patrons of these locations at all times
 
-**Consequence**: A private, written warning from community leaders, providing
-clarity around the nature of the violation and an explanation of why the
-behavior was inappropriate. A public apology may be requested.
+## Unacceptable Behavior
 
-### 2. Warning
+The following behaviors are considered harassment and are unacceptable within our community:
+- Violence, threats of violence or violent language directed against another person.
+- Sexist, racist, homophobic, transphobic, ableist or otherwise discriminatory jokes and language.
+- Posting or displaying sexually explicit or violent material.
+- Posting or threatening to post other people’s personally identifying information ("doxing").
+- Personal insults, particularly those related to gender, sexual orientation, race, religion, or disability.
+- Inappropriate photography or recording.
+- Inappropriate physical contact. You should have someone’s consent before touching them in any manner.
+- Unwelcome sexual attention. This includes sexualized comments or jokes; inappropriate touching, groping, and unwelcome sexual advances.
+- Deliberate intimidation, stalking or following (online or in person).
+- Advocating for, or encouraging, any of the above behavior.
+- Repeated harassment of others. In general, if someone asks you to stop, then stop.
+- Other conduct which could reasonably be considered inappropriate in a professional setting.
 
-**Community Impact**: A violation through a single incident or series
-of actions.
+## Weapons Policy
 
-**Consequence**: A warning with consequences for continued behavior. No
-interaction with the people involved, including unsolicited interaction with
-those enforcing the Code of conduct, for a specified period of time. This
-includes avoiding interactions in community spaces as well as external channels
-like social media. Violating these terms may lead to a temporary or
-permanent ban.
+No weapons will be allowed at Tuist events, office locations, or in other spaces covered by the scope of this Code of Conduct. Weapons include but are not limited to guns, explosives (including fireworks), and large knives such as those used for hunting or display, as well as any other item used for the purpose of causing injury or harm to others.
+Anyone seen in possession of one of these items will be asked to leave immediately and will be subject to punitive action up to and including termination and involvement of law enforcement authorities. Tuist staff are further expected to comply with all state and local laws on this matter.
 
-### 3. Temporary ban
+## Consequences of Unacceptable Behavior
 
-**Community Impact**: A serious violation of community standards, including
-sustained inappropriate behavior.
+Unacceptable behavior from any Tuist staff, including those with decision-making authority, will not be tolerated.
+Anyone asked to stop unacceptable behavior is expected to comply immediately.
 
-**Consequence**: A temporary ban from any sort of interaction or public
-communication with the community for a specified period of time. No public or
-private interaction with the people involved, including unsolicited interaction
-with those enforcing the Code of conduct, is allowed during this period.
-Violating these terms may lead to a permanent ban.
+If a staff member engages in unacceptable behavior, Tuist leadership may take any action deemed appropriate, up to and including suspension or termination.
 
-### 4. Permanent ban
+## Reporting Violations
 
-**Community Impact**: Demonstrating a pattern of violation of community
-standards, including sustained inappropriate behavior,  harassment of an
-individual, or aggression toward or disparagement of classes of individuals.
+If you are subject to or witness unacceptable behavior, or have any other concerns, please notify an appropriate member of Tuist leadership as soon as possible.
 
-**Consequence**: A permanent ban from any sort of public interaction within
-the community
+It is a violation of this policy to retaliate against any person making a complaint of Unacceptable Behavior or against any person participating in the investigation of (including testifying as a witness to) any such allegation. Any retaliation or intimidation may be subject to punitive action up to and including termination.
 
-## Attribution
+## Disciplinary Action
 
-This Code of conduct is adapted from [PostHog's code of conduct](https://posthog.com/docs/contribute/code-of-conduct).
+Employees who violate this policy may face disciplinary consequences in proportion to their violation. Tuist management will determine how serious an employee’s offense is and take the appropriate action
 
-For answers to common questions about this code of conduct, see the
-[https://www.contributor-covenant.org/faq][FAQ]. Also available are [translations](https://www.contributor-covenant.org/translations).
+## Version history
 
-[homepage]: https://www.contributor-covenant.org
-[v2.0]: https://www.contributor-covenant.org/version/2/0/code_of_conduct.html
-[Mozilla CoC]: https://github.com/mozilla/diversity
-[FAQ]: https://www.contributor-covenant.org/faq
-[translations]: https://www.contributor-covenant.org/translations
+The version history of this document can be found in Tuist's [handbook](https://github.com/tuist/handbook) repository.


### PR DESCRIPTION
We started to work towards getting the SOC2 Type 1 compliance certification. As part of that, I'm updating the code of conduct using the one suggested by Vanta. I added the Spanish and German version of them since we plan to hire people in countries where those are the languages spoken. Note that those versions are also generated by Vanta, so I simply copied and pasted them.