### PR TITLE
Propose projects scoped to 6-week cycles

### DIFF
--- a/.vitepress/config.mjs
+++ b/.vitepress/config.mjs
@@ -81,6 +81,7 @@ export default defineConfig({
           { text: "Principles", link: "/company/principles" },
           { text: "Services and tools", link: "/company/services-and-tools" },
           { text: "Leadership", link: "/company/leadership" },
+          { text: "6-week cycles", link: "/company/6-week-cycles" },
         ],
       },
       {

--- a/handbook/company/6-week-cycles.md
+++ b/handbook/company/6-week-cycles.md
@@ -1,7 +1,7 @@
 ---
 title: 6-week cycles
 titleTemplate: :title | Company | Tuist Handbook
-mission: Learn more about the leadership team at Tuist
+mission: Understand Tuist's 6-week project cycle approach and its benefits
 ---
 
 # 6-week cycles

--- a/handbook/company/6-week-cycles.md
+++ b/handbook/company/6-week-cycles.md
@@ -1,0 +1,66 @@
+---
+title: 6-week cycles
+titleTemplate: :title | Company | Tuist Handbook
+mission: Learn more about the leadership team at Tuist
+---
+
+# 6-week cycles
+
+At Tuist, we shape projects to be executable in 6-week cycles. We believe this timeframe strikes the perfect balance: long enough to deliver meaningful value to teams and developers using Tuist, yet short enough to maintain momentum, focus, and a sense of progress.
+
+With our current company size, most projects will typically involve one full-time engineer, while designers work across multiple projects simultaneously, providing their expertise where needed.
+
+> [!NOTE]
+> Software estimation is inherently challenging. Even when we carefully scope work to fit within a 6-week cycle and aim to eliminate unknowns, unforeseen issues may still arise during development. When this happens, we commit to discussing challenges openly and collaboratively to find solutions that work for everyone.
+
+## 2025 Calendar
+
+### 3rd cycle / April 9 - May 20, 2025
+- Week 1: Apr 9 - Apr 15
+- Week 2: Apr 16 - Apr 22
+- Week 3: Apr 23 - Apr 29
+- Week 4: Apr 30 - May 6
+- Week 5: May 7 - May 13
+- Week 6: May 14 - May 20
+- **Cooldown week:** May 21 - May 27
+
+### 4th cycle / May 28 - July 8, 2025
+- Week 1: May 28 - Jun 3
+- Week 2: Jun 4 - Jun 10
+- Week 3: Jun 11 - Jun 17
+- Week 4: Jun 18 - Jun 24
+- Week 5: Jun 25 - Jul 1
+- Week 6: Jul 2 - Jul 8
+- **Cooldown week:** Jul 9 - Jul 15
+
+### 5th cycle / July 16 - August 26, 2025
+- Week 1: Jul 16 - Jul 22
+- Week 2: Jul 23 - Jul 29
+- Week 3: Jul 30 - Aug 5
+- Week 4: Aug 6 - Aug 12
+- Week 5: Aug 13 - Aug 19
+- Week 6: Aug 20 - Aug 26
+- **Cooldown week:** Aug 27 - Sep 2
+
+### 6th cycle / September 3 - October 14, 2025
+- Week 1: Sep 3 - Sep 9
+- Week 2: Sep 10 - Sep 16
+- Week 3: Sep 17 - Sep 23
+- Week 4: Sep 24 - Sep 30
+- Week 5: Oct 1 - Oct 7
+- Week 6: Oct 8 - Oct 14
+- **Cooldown week:** Oct 15 - Oct 21
+
+### 7th cycle / October 22 - December 2, 2025
+- Week 1: Oct 22 - Oct 28
+- Week 2: Oct 29 - Nov 4
+- Week 3: Nov 5 - Nov 11
+- Week 4: Nov 12 - Nov 18
+- Week 5: Nov 19 - Nov 25
+- Week 6: Nov 26 - Dec 2
+- **Cooldown week:** Dec 3 - Dec 9
+
+### 8th cycle / December 10 - December 31, 2025 (shortened cycle)
+- Week 1: Dec 10 - Dec 16
+- Week 2: Dec 17 - Dec 23
+- Week 3: Dec 24 - Dec 31 (extended week to match year-end)


### PR DESCRIPTION
Inspired by Basecamp's shape up and our experience at Shopify, we'd like to propose to scope projects based on a cycle size of 6 weeks. Having a bit of a structure here helps with:

- Forcing us to scope projects such that they can be delivered in a reasonable time frame.
- Preventing projects that drag forever and prompting us to adjust the scope if unforeseen issues arise.
- Aligning things like [community events](https://github.com/tuist/design/issues/1#issuecomment-2694841285) with the cycles
- Having a predictable release schedule which we can align marketing efforts with.
